### PR TITLE
Clean up German translation file

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -10,12 +10,10 @@ msgstr ""
 "POT-Creation-Date: 2011-10-25 01:40+0400\n"
 "PO-Revision-Date: 2018-03-03 11:52+0100\n"
 "Last-Translator: Thomas Perl <m@thp.io>\n"
-"Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
 "Language: German\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Poedit-Basepath: c:\\docume~1\\roland\\desktop\\tmp\\bombono-dvd-0.9.0\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 #: src/mbase/project/media.cpp:68 src/mgui/project/media-browser.cpp:885


### PR DESCRIPTION
The translation is no longer assigned to the Translation Project, so remove the team.
There is no need to mention the Poedit working directory.